### PR TITLE
Publish documentation to gh-pages branch on merge to master

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,0 +1,31 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node_version: '12'
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npm run build:docs
+      - name: Deploy to GitHub Pages
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: gh-pages
+          build_dir: docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+docs

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "format:check": "npm run prettier -- --list-different",
     "format:fix": "npm run prettier -- --write",
     "validate": "npm-run-all lint format:check",
+    "prebuild:docs": "rimraf docs",
+    "build:docs": "build-storybook -o docs",
     "prebuild": "rimraf dist && npm run validate",
     "build": "webpack",
     "start": "start-storybook -p 8080"


### PR DESCRIPTION
This PR enables automated deploys of storybook documentation to the `gh-pages` branch which will automatically deploy to https://brownuniversity.github.io/brown-university-styles/. This will ultimately replace design.cis.brown.edu.